### PR TITLE
Remove header from experience page; fix gap above nav bar

### DIFF
--- a/experience-esp.html
+++ b/experience-esp.html
@@ -17,13 +17,13 @@
           <li><a href="index-esp.html"><img src="images/Spain.png" alt="link to page in Spanish" width="20px" height="20px"></a></li>
         </ul>
     </div>
-
+<!-- 
     <header>
       <img src="images/Profile-image.jpg" alt="Image of passing subway car" class="profile-image">
       <h1 class="tag name">Hola, soy Martin.</h1>
       <p class="tag location">Vivo en Doha de Qatar. <br>(No aparece in la foto.)</p>
     </header>
-
+ -->
     <main class="flex-exp">
       <div class="card exp">
         <h2>Educación</h2>

--- a/experience.html
+++ b/experience.html
@@ -17,13 +17,13 @@
           <li><a href="experience-esp.html"><img src="images/Spain.png" alt="link to page in Spanish" width="20px" height="20px"></a></li>
         </ul>
     </div>
-
+<!-- 
     <header>
       <img src="images/Profile-image.jpg" alt="Image of passing subway car" class="profile-image">
       <h1 class="tag name">Hi, I’m Martin.</h1>
       <p class="tag location">Living in Doha, Qatar. <br>(Not pictured.)</p>
     </header>
-
+ -->
     <main class="flex-exp">
       <div class="card exp">
         <h2>Education</h2>

--- a/styles.css
+++ b/styles.css
@@ -54,23 +54,7 @@ a:hover {
 .nav a:hover {
   color: white
 }
-/*
-a.language {
-  margin-left: 5px;
-  text-indent: -9999px;
-  width: 30px;
-  height: 30px;
-  background-size: 30px 30px;
 
-}
-a.english {
-  background-image: url(images/UnitedKingdom.png);
-}
-
-a.spanish {
-  background-image: url(images/Spain.png);
-}
-*/
 .exp-nav {
   display: flex;
 }
@@ -125,8 +109,9 @@ header .profile-image:hover {
 }
 
 .flex-exp {
-  margin-top: 60px;
+  padding-top: 60px;
 }
+
 .card:hover {
   border-color: #666699;
 }


### PR DESCRIPTION
Removed headers from experience.html and experience-esp.html and added
60px margin to class .flex-exp. (Previously, attempts to remove header
caused the nav bar to overlap with the first .card and leave a gap
above the nav bar.)